### PR TITLE
Add basic tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,14 @@
+import subprocess
+import sys
+import language_tutor
+
+
+def test_cli_version():
+    result = subprocess.run(
+        [sys.executable, '-m', 'language_tutor.cli', '--version'],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    expected = f"Language Tutor v{language_tutor.__version__}"
+    assert expected in result.stdout.strip()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,18 @@
+import os
+from language_tutor import config
+
+
+def test_get_config_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv('XDG_CONFIG_HOME', str(tmp_path))
+    path = config.get_config_dir()
+    assert path == os.path.join(tmp_path, 'language-tutor')
+    assert os.path.isdir(path)
+
+
+def test_get_paths(tmp_path, monkeypatch):
+    monkeypatch.setenv('XDG_CONFIG_HOME', str(tmp_path))
+    config_dir = config.get_config_dir()
+    assert config.get_config_path() == os.path.join(config_dir, 'config.json')
+    assert config.get_state_path() == os.path.join(config_dir, 'state.json')
+    export = config.get_export_path()
+    assert os.path.isdir(export)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,12 @@
+import asyncio
+from language_tutor import utils
+
+
+async def _dummy():
+    await asyncio.sleep(0.01)
+    return 42
+
+
+def test_run_async():
+    result = utils.run_async(_dummy(), in_q_application=False)
+    assert result == 42

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,6 @@
+import language_tutor
+
+
+def test_version_defined():
+    assert isinstance(language_tutor.__version__, str)
+    assert language_tutor.__version__


### PR DESCRIPTION
## Summary
- add tests for CLI, config utilities, run_async helper, and version

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*