### PR TITLE
Update setuptools packages list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,12 @@ Issues = "https://github.com/username/language-tutor/issues"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
-packages = ["language_tutor", "language_tutor.languages"]
+packages = [
+    "language_tutor",
+    "language_tutor.languages",
+    "language_tutor.gui_screens",
+    "language_tutor.screens",
+]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary
- extend setuptools packages list for packaging

## Testing
- `pip install . --no-build-isolation --no-deps` *(fails: Cannot import 'setuptools.build_meta')*
