### PR TITLE
Refactor LLM access into abstract class with OpenAI adapter

### DIFF
--- a/src/language_tutor/app.py
+++ b/src/language_tutor/app.py
@@ -6,7 +6,7 @@ import os
 import random
 import importlib.resources as resources
 from dotenv import load_dotenv
-import litellm
+from language_tutor import llm
 from textual.app import App, ComposeResult
 from textual.containers import Container, Horizontal, Vertical
 from textual.widgets import (
@@ -260,17 +260,15 @@ class LanguageTutorApp(App):
 
     def on_mount(self) -> None:
         """Called when the app is mounted."""
-        # Configure LiteLLM to use OpenRouter
-        litellm.api_key = os.getenv("OPENROUTER_API_KEY")
-        litellm.base_url = (
-            "https://openrouter.ai/api/v1"  # Or the specific OpenRouter endpoint
-        )
+        # Configure LLM
+        llm.set_api_key(os.getenv("OPENROUTER_API_KEY", ""))
+        llm.set_base_url("https://openrouter.ai/api/v1")
 
         self.load_config()  # Restore config on start
         api_key = os.getenv("OPENROUTER_API_KEY")
         if api_key:
-            litellm.api_key = api_key
-        if not litellm.api_key:
+            llm.set_api_key(api_key)
+        if not llm.is_configured():
             self.notify(
                 "Error: OPENROUTER_API_KEY not found in .env file. Please configure it in Settings (Ctrl+,).",
                 severity="error",
@@ -391,7 +389,7 @@ class LanguageTutorApp(App):
                 severity="warning",
             )
             return
-        if not litellm.api_key:
+        if not llm.is_configured():
             self.notify(
                 "API Key not configured. Please set your OpenRouter API key in Settings (Ctrl+,).",
                 severity="error",
@@ -446,7 +444,7 @@ class LanguageTutorApp(App):
                 severity="warning",
             )
             return
-        if not litellm.api_key:
+        if not llm.is_configured():
             self.notify(
                 "API Key not configured. Please set your OpenRouter API key in Settings (Ctrl+,).",
                 severity="error",

--- a/src/language_tutor/gui_app.py
+++ b/src/language_tutor/gui_app.py
@@ -4,7 +4,7 @@ import os
 import json
 import random
 import datetime
-import litellm
+from language_tutor import llm
 from dotenv import load_dotenv
 from PyQt5.QtWidgets import (
     QMainWindow, QWidget, QVBoxLayout, QHBoxLayout, 
@@ -50,15 +50,15 @@ class LanguageTutorGUI(QMainWindow):
         self._setup_menu()
         self._load_config()
         
-        # Configure LiteLLM
+        # Configure LLM
         env_path = os.path.join(get_config_dir(), ".env")
         if os.path.exists(env_path):
             load_dotenv(env_path)
-        litellm.api_key = os.getenv("OPENROUTER_API_KEY")
-        litellm.base_url = "https://openrouter.ai/api/v1"
+        llm.set_api_key(os.getenv("OPENROUTER_API_KEY", ""))
+        llm.set_base_url("https://openrouter.ai/api/v1")
         
         # Check for API key
-        if not litellm.api_key:
+        if not llm.is_configured():
             self.statusBar().showMessage(
                 "Error: API Key not configured. Please configure it in Settings.",
                 10000
@@ -418,7 +418,7 @@ class LanguageTutorGUI(QMainWindow):
             )
             return
             
-        if not litellm.api_key:
+        if not llm.is_configured():
             QMessageBox.critical(
                 self,
                 "API Key Required",
@@ -475,7 +475,7 @@ class LanguageTutorGUI(QMainWindow):
             )
             return
             
-        if not litellm.api_key:
+        if not llm.is_configured():
             QMessageBox.critical(
                 self,
                 "API Key Required",
@@ -642,5 +642,5 @@ class LanguageTutorGUI(QMainWindow):
         
         if result == SettingsDialog.Accepted:
             # Reload API key
-            litellm.api_key = os.getenv("OPENROUTER_API_KEY")
+            llm.set_api_key(os.getenv("OPENROUTER_API_KEY", ""))
             self.statusBar().showMessage("Settings updated successfully.", 3000)

--- a/src/language_tutor/gui_screens/qa_dialog.py
+++ b/src/language_tutor/gui_screens/qa_dialog.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-import litellm
+from language_tutor import llm
 from PyQt5.QtWidgets import (
     QDialog,
     QVBoxLayout,
@@ -157,7 +157,7 @@ class QADialog(QDialog):
             )
             return
 
-        if not litellm.api_key:
+        if not llm.is_configured():
             from PyQt5.QtWidgets import QMessageBox
 
             QMessageBox.critical(

--- a/src/language_tutor/gui_screens/settings_dialog.py
+++ b/src/language_tutor/gui_screens/settings_dialog.py
@@ -2,7 +2,7 @@
 
 import os
 import json
-import litellm
+from language_tutor import llm
 from PyQt5.QtWidgets import (
     QDialog, QVBoxLayout, QLabel, QLineEdit, 
     QPushButton, QHBoxLayout, QMessageBox
@@ -87,7 +87,7 @@ class SettingsDialog(QDialog):
                 f.write(f"OPENROUTER_API_KEY={api_key}\n")
             
             os.environ["OPENROUTER_API_KEY"] = api_key
-            litellm.api_key = api_key
+            llm.set_api_key(api_key)
             
             self.status_label.setText("API key saved successfully!")
             self.status_label.setStyleSheet("color: green;")

--- a/src/language_tutor/llm.py
+++ b/src/language_tutor/llm.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+"""Abstractions for interacting with different language model libraries."""
+
+from abc import ABC, abstractmethod
+import os
+from typing import Any, List, Tuple, Optional
+
+from .config import MODEL_PRICE_PER_TOKEN
+
+
+class LLM(ABC):
+    """Abstract interface for language model integrations."""
+
+    @abstractmethod
+    def set_api_key(self, key: str) -> None:
+        """Configure the API key used for LLM calls."""
+
+    @abstractmethod
+    def get_api_key(self) -> str:
+        """Return the configured API key."""
+
+    @abstractmethod
+    def is_configured(self) -> bool:
+        """Return ``True`` if an API key has been set."""
+
+    @abstractmethod
+    def set_base_url(self, url: str) -> None:
+        """Set the base URL for API requests."""
+
+    @abstractmethod
+    def get_base_url(self) -> str:
+        """Return the base URL for API requests."""
+
+    @abstractmethod
+    async def completion(self, model: str, messages: List[dict], **kwargs: Any) -> Tuple[Any, Optional[float]]:
+        """Run an asynchronous completion.
+
+        Returns the raw response object along with a floating point cost if
+        available. Implementations may return ``None`` for the cost if it cannot
+        be calculated.
+        """
+
+
+class LiteLLM(LLM):
+    """Adapter that uses the :mod:`litellm` package."""
+
+    DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+
+    def __init__(self) -> None:
+        import litellm  # local import to avoid unnecessary dependency at import time
+
+        self._litellm = litellm
+        self._litellm.api_key = os.getenv("OPENROUTER_API_KEY", self._litellm.api_key)
+        self._litellm.base_url = os.getenv("OPENROUTER_BASE_URL", self.DEFAULT_BASE_URL)
+
+    def set_api_key(self, key: str) -> None:
+        self._litellm.api_key = key
+        os.environ["OPENROUTER_API_KEY"] = key
+
+    def get_api_key(self) -> str:
+        return self._litellm.api_key or ""
+
+    def is_configured(self) -> bool:
+        return bool(self._litellm.api_key)
+
+    def set_base_url(self, url: str) -> None:
+        self._litellm.base_url = url
+        os.environ["OPENROUTER_BASE_URL"] = url
+
+    def get_base_url(self) -> str:
+        return self._litellm.base_url
+
+    async def completion(self, model: str, messages: List[dict], **kwargs: Any) -> Tuple[Any, Optional[float]]:
+        response = await self._litellm.acompletion(
+            model=model,
+            messages=messages,
+            api_base=self._litellm.base_url,
+            **kwargs,
+        )
+
+        from litellm import completion_cost
+
+        model_name = model.split("/")[-1].split(":")[0]
+        cost_info = MODEL_PRICE_PER_TOKEN.get(model_name)
+        cost = completion_cost(response, custom_cost_per_token=cost_info) if cost_info else None
+        return response, cost
+
+
+class OpenAILLM(LLM):
+    """Adapter for the :mod:`openai` library."""
+
+    DEFAULT_BASE_URL = "https://api.openai.com/v1"
+
+    def __init__(self) -> None:
+        self._api_key = os.getenv("OPENAI_API_KEY", "")
+        self._base_url = os.getenv("OPENAI_BASE_URL", self.DEFAULT_BASE_URL)
+
+    def set_api_key(self, key: str) -> None:
+        self._api_key = key
+        os.environ["OPENAI_API_KEY"] = key
+
+    def get_api_key(self) -> str:
+        return self._api_key
+
+    def is_configured(self) -> bool:
+        return bool(self._api_key)
+
+    def set_base_url(self, url: str) -> None:
+        self._base_url = url
+        os.environ["OPENAI_BASE_URL"] = url
+
+    def get_base_url(self) -> str:
+        return self._base_url
+
+    async def completion(self, model: str, messages: List[dict], **kwargs: Any) -> Tuple[Any, Optional[float]]:
+        try:
+            import openai  # type: ignore
+        except Exception as exc:  # pragma: no cover - openai optional
+            raise RuntimeError("openai library is required for OpenAILLM") from exc
+
+        openai.api_key = self._api_key
+        if hasattr(openai, "api_base"):
+            openai.api_base = self._base_url  # type: ignore[attr-defined]
+        response = await openai.ChatCompletion.acreate(
+            model=model,
+            messages=messages,
+            **kwargs,
+        )
+        # The openai library doesn't provide cost calculation directly
+        cost = None
+        return response, cost
+
+
+_active_llm: LLM = LiteLLM()
+
+
+def use_llm(instance: LLM) -> None:
+    """Set the globally used LLM implementation."""
+    global _active_llm
+    _active_llm = instance
+
+
+def get_llm() -> LLM:
+    """Return the currently active LLM implementation."""
+    return _active_llm
+
+
+# Convenience wrappers for backwards compatibility
+
+def set_api_key(key: str) -> None:
+    _active_llm.set_api_key(key)
+
+
+def get_api_key() -> str:
+    return _active_llm.get_api_key()
+
+
+def is_configured() -> bool:
+    return _active_llm.is_configured()
+
+
+def set_base_url(url: str) -> None:
+    _active_llm.set_base_url(url)
+
+
+def get_base_url() -> str:
+    return _active_llm.get_base_url()
+
+
+async def completion(model: str, messages: List[dict], **kwargs: Any) -> Tuple[Any, Optional[float]]:
+    return await _active_llm.completion(model=model, messages=messages, **kwargs)

--- a/src/language_tutor/screens/qa_screen.py
+++ b/src/language_tutor/screens/qa_screen.py
@@ -9,6 +9,7 @@ from textual.widgets import Button, Select, Static, TextArea, Markdown, Footer, 
 from textual.binding import Binding
 from language_tutor.config import AI_MODELS
 from language_tutor.utils import answer_question
+from language_tutor import llm
 
 
 class QuestionTextArea(TextArea):
@@ -121,9 +122,7 @@ class QAScreen(Screen):
             self.app.notify("Please enter a question first.", severity="warning")
             return
 
-        import litellm
-
-        if not litellm.api_key:
+        if not llm.is_configured():
             self.app.notify(
                 "API Key not configured. Cannot send question.", severity="error"
             )

--- a/src/language_tutor/screens/settings_screen.py
+++ b/src/language_tutor/screens/settings_screen.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-import litellm
+from language_tutor import llm
 
 from pathlib import Path
 import asyncio
@@ -82,7 +82,7 @@ class SettingsScreen(Screen):
                 f.write(f"OPENROUTER_API_KEY={api_key}\n")
 
             os.environ["OPENROUTER_API_KEY"] = api_key
-            litellm.api_key = api_key
+            llm.set_api_key(api_key)
 
             status.update("API key saved successfully!")
 

--- a/src/language_tutor/utils.py
+++ b/src/language_tutor/utils.py
@@ -2,11 +2,9 @@
 
 import re
 import random
-import litellm
-from litellm import completion_cost
 import asyncio
 import nest_asyncio
-from language_tutor.config import MODEL_PRICE_PER_TOKEN
+from language_tutor import llm
 from PyQt5.QtWidgets import QApplication
 
 async def generate_exercise(language, level, exercise_type, definitions):
@@ -42,8 +40,7 @@ Format the output EXACTLY like this, using these specific headings:
     messages = [{"role": "user", "content": prompt}]
 
     # Make the async API call
-    response = await litellm.acompletion(model=OR_MODEL_NAME, messages=messages, api_base=litellm.base_url)
-    cost = completion_cost(response, custom_cost_per_token=MODEL_PRICE_PER_TOKEN[OR_MODEL_NAME.split("/")[-1]])
+    response, cost = await llm.completion(model=OR_MODEL_NAME, messages=messages)
 
     full_response_content = response.choices[0].message.content
 
@@ -112,8 +109,7 @@ Format the output EXACTLY like this, using these specific headings:
     model_name = OR_MODEL_NAME_CHECK
 
     # Make the async API call
-    response = await litellm.acompletion(model=model_name, messages=messages, api_base=litellm.base_url)
-    cost = completion_cost(response, custom_cost_per_token=MODEL_PRICE_PER_TOKEN[model_name.split("/")[-1]])
+    response, cost = await llm.completion(model=model_name, messages=messages)
     feedback_content = response.choices[0].message.content
 
     # --- Basic Parsing ---
@@ -157,18 +153,7 @@ Please provide a helpful, educational response focused on language learning."""
     
     # Make the API call
     messages = [{"role": "user", "content": prompt}]
-    response = await litellm.acompletion(
-        model=model, 
-        messages=messages, 
-        api_base=litellm.base_url
-    )
-    
-    # Try to calculate cost
-    model_name = model.split("/")[-1].split(":")[0]
-    if model_name in MODEL_PRICE_PER_TOKEN:
-        cost = completion_cost(response, custom_cost_per_token=MODEL_PRICE_PER_TOKEN[model_name])
-    else:
-        cost = None
+    response, cost = await llm.completion(model=model, messages=messages)
     
     # Get the response
     answer = response.choices[0].message.content


### PR DESCRIPTION
## Summary
- refactor `language_tutor.llm` into an abstract class hierarchy
- keep LiteLLM behaviour in `LiteLLM` subclass
- add new `OpenAILLM` implementation with placeholder cost handling
- expose convenience wrappers that delegate to a global LLM instance

## Testing
- `pytest -q` *(fails: command not found)*
