### PR TITLE
Refactor to use LLM instance directly

### DIFF
--- a/src/language_tutor/app.py
+++ b/src/language_tutor/app.py
@@ -6,7 +6,7 @@ import os
 import random
 import importlib.resources as resources
 from dotenv import load_dotenv
-from language_tutor import llm
+from language_tutor.llm import llm
 from textual.app import App, ComposeResult
 from textual.containers import Container, Horizontal, Vertical
 from textual.widgets import (

--- a/src/language_tutor/gui_app.py
+++ b/src/language_tutor/gui_app.py
@@ -4,7 +4,7 @@ import os
 import json
 import random
 import datetime
-from language_tutor import llm
+from language_tutor.llm import llm
 from dotenv import load_dotenv
 from PyQt5.QtWidgets import (
     QMainWindow, QWidget, QVBoxLayout, QHBoxLayout, 

--- a/src/language_tutor/gui_screens/qa_dialog.py
+++ b/src/language_tutor/gui_screens/qa_dialog.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-from language_tutor import llm
+from language_tutor.llm import llm
 from PyQt5.QtWidgets import (
     QDialog,
     QVBoxLayout,

--- a/src/language_tutor/gui_screens/settings_dialog.py
+++ b/src/language_tutor/gui_screens/settings_dialog.py
@@ -2,7 +2,7 @@
 
 import os
 import json
-from language_tutor import llm
+from language_tutor.llm import llm
 from PyQt5.QtWidgets import (
     QDialog, QVBoxLayout, QLabel, QLineEdit, 
     QPushButton, QHBoxLayout, QMessageBox

--- a/src/language_tutor/llm.py
+++ b/src/language_tutor/llm.py
@@ -2,47 +2,20 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Tuple, Optional
-
 from .llms import LLM, LiteLLM, OpenAILLM
 
 
-# Default to LiteLLM implementation
-_active_llm: LLM = LiteLLM()
+# Single instance of the configured LLM backend
+llm: LLM = LiteLLM()
 
 
 def use_llm(instance: LLM) -> None:
-    """Set the globally used LLM implementation."""
-    global _active_llm
-    _active_llm = instance
+    """Replace the globally used LLM implementation."""
+    global llm
+    llm = instance
 
 
 def get_llm() -> LLM:
-    """Return the currently active LLM implementation."""
-    return _active_llm
+    """Return the currently configured LLM instance."""
+    return llm
 
-
-# Convenience wrappers for backwards compatibility
-
-def set_api_key(key: str) -> None:
-    _active_llm.set_api_key(key)
-
-
-def get_api_key() -> str:
-    return _active_llm.get_api_key()
-
-
-def is_configured() -> bool:
-    return _active_llm.is_configured()
-
-
-def set_base_url(url: str) -> None:
-    _active_llm.set_base_url(url)
-
-
-def get_base_url() -> str:
-    return _active_llm.get_base_url()
-
-
-async def completion(model: str, messages: List[dict], **kwargs: Any) -> Tuple[Any, Optional[float]]:
-    return await _active_llm.completion(model=model, messages=messages, **kwargs)

--- a/src/language_tutor/screens/qa_screen.py
+++ b/src/language_tutor/screens/qa_screen.py
@@ -9,7 +9,7 @@ from textual.widgets import Button, Select, Static, TextArea, Markdown, Footer, 
 from textual.binding import Binding
 from language_tutor.config import AI_MODELS
 from language_tutor.utils import answer_question
-from language_tutor import llm
+from language_tutor.llm import llm
 
 
 class QuestionTextArea(TextArea):

--- a/src/language_tutor/screens/settings_screen.py
+++ b/src/language_tutor/screens/settings_screen.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-from language_tutor import llm
+from language_tutor.llm import llm
 
 from pathlib import Path
 import asyncio

--- a/src/language_tutor/utils.py
+++ b/src/language_tutor/utils.py
@@ -4,7 +4,7 @@ import re
 import random
 import asyncio
 import nest_asyncio
-from language_tutor import llm
+from language_tutor.llm import llm
 from PyQt5.QtWidgets import QApplication
 
 async def generate_exercise(language, level, exercise_type, definitions):


### PR DESCRIPTION
## Summary
- expose the active LLM object in `llm.py`
- update imports to use the LLM instance directly across the codebase

## Testing
- `pytest -q` *(fails: command not found)*