### PR TITLE
Add dialog-based save/load with autosave

### DIFF
--- a/src/language_tutor/app.py
+++ b/src/language_tutor/app.py
@@ -29,6 +29,8 @@ from language_tutor.config import (
     get_export_path,
     get_config_dir,
 )
+from language_tutor.state import LanguageTutorState
+from tkinter import Tk, filedialog
 from language_tutor.exercise import generate_exercise, check_writing
 from language_tutor.screens import QAScreen, SettingsScreen
 
@@ -103,46 +105,82 @@ class LanguageTutorApp(App):
             except Exception as e:
                 self.notify(f"Error loading config: {e}", severity="error")
 
-    def save_state(self):
-        """Save the current application state to state.json."""
+    def _ask_save_path(self) -> str | None:
+        """Open a save file dialog and return the selected path."""
+        root = Tk()
+        root.withdraw()
+        path = filedialog.asksaveasfilename(
+            defaultextension=".lts",
+            filetypes=[
+                ("Language Tutor State", "*.lts"),
+                ("JSON", "*.json"),
+                ("All files", "*.*"),
+            ],
+        )
+        root.destroy()
+        return path or None
+
+    def _ask_open_path(self) -> str | None:
+        """Open a load file dialog and return the selected path."""
+        root = Tk()
+        root.withdraw()
+        path = filedialog.askopenfilename(
+            filetypes=[
+                ("Language Tutor State", "*.lts *.json"),
+                ("All files", "*.*"),
+            ]
+        )
+        root.destroy()
+        return path or None
+
+    def save_state(self, path: str | None = None, auto: bool = False) -> None:
+        """Save the current application state."""
+        if path is None and not auto:
+            path = self._ask_save_path()
+        if path is None:
+            path = get_state_path()
         try:
-            state = {
-                "selected_language": self.selected_language,
-                "selected_exercise": self.selected_exercise,
-                "selected_level": self.selected_level,
-                "generated_exercise": self.generated_exercise,
-                "generated_hints": self.generated_hints,
-                "writing_input": self.writing_input,
-                "mistakes": self.writing_mistakes,
-                "style": self.style_errors,
-                "recs": self.recommendations,
-            }
-            with open(get_state_path(), "w") as f:
-                json.dump(state, f)
-            self.notify("State saved successfully.")
+            state = LanguageTutorState(
+                selected_language=self.selected_language,
+                selected_exercise=self.selected_exercise,
+                selected_level=self.selected_level,
+                generated_exercise=self.generated_exercise,
+                generated_hints=self.generated_hints,
+                writing_input=self.writing_input,
+                writing_mistakes=self.writing_mistakes,
+                style_errors=self.style_errors,
+                recommendations=self.recommendations,
+            )
+            state.save(path)
+            if not auto:
+                self.notify("State saved successfully.")
         except Exception as e:
             self.notify(f"Error saving state: {e}", severity="error")
 
-    def load_state(self):
-        """Load the application state from state.json."""
-        if not os.path.exists(get_state_path()):
-            self.notify("No saved state found.", severity="warning")
+    def load_state(self, path: str | None = None, auto: bool = False) -> None:
+        """Load the application state."""
+        if path is None and not auto:
+            path = self._ask_open_path()
+        if path is None:
+            path = get_state_path()
+        if not os.path.exists(path):
+            if not auto:
+                self.notify("No saved state found.", severity="warning")
             return
         try:
-            with open(get_state_path(), "r") as f:
-                state = json.load(f)
+            state = LanguageTutorState.load(path)
             # Restore selections
-            self.selected_language = state.get("selected_language", "")
+            self.selected_language = state.selected_language
             self._reload_definitions()
 
-            self.selected_exercise = state.get("selected_exercise", "")
-            self.selected_level = state.get("selected_level", "")
-            self.generated_exercise = state.get("generated_exercise", "")
-            self.generated_hints = state.get("generated_hints", "")
-            self.writing_input = state.get("writing_input", "")
-            self.writing_mistakes = state.get("mistakes", "")
-            self.style_errors = state.get("style", "")
-            self.recommendations = state.get("recs", "")
+            self.selected_exercise = state.selected_exercise
+            self.selected_level = state.selected_level
+            self.generated_exercise = state.generated_exercise
+            self.generated_hints = state.generated_hints
+            self.writing_input = state.writing_input
+            self.writing_mistakes = state.writing_mistakes
+            self.style_errors = state.style_errors
+            self.recommendations = state.recommendations
 
             # Restore Select widgets
             self.query_one("#language-select", Select).value = self.selected_language
@@ -159,7 +197,8 @@ class LanguageTutorApp(App):
             self.query_one("#style-display", Markdown).update(self.style_errors)
             self.query_one("#recs-display", Markdown).update(self.recommendations)
 
-            self.notify("State loaded successfully.")
+            if not auto:
+                self.notify("State loaded successfully.")
         except Exception as e:
             self.notify(f"Error loading state: {e}", severity="error")
 
@@ -265,6 +304,7 @@ class LanguageTutorApp(App):
         llm.set_base_url("https://openrouter.ai/api/v1")
 
         self.load_config()  # Restore config on start
+        self.load_state(auto=True)
         api_key = os.getenv("OPENROUTER_API_KEY")
         if api_key:
             llm.set_api_key(api_key)
@@ -489,6 +529,10 @@ class LanguageTutorApp(App):
             # Reset button state
             check_btn.loading = False
             check_btn.disabled = False
+
+    def on_shutdown(self) -> None:
+        """Automatically save the application state when exiting."""
+        self.save_state(auto=True)
 
 
 def run_app():

--- a/src/language_tutor/gui_app.py
+++ b/src/language_tutor/gui_app.py
@@ -51,6 +51,8 @@ class LanguageTutorGUI(QMainWindow):
         self._setup_ui()
         self._setup_menu()
         self._load_config()
+        # Restore previous session if available
+        self.load_state(auto=True)
         
         # Configure LLM
         env_path = os.path.join(get_config_dir(), ".env")
@@ -572,22 +574,42 @@ class LanguageTutorGUI(QMainWindow):
         """Handle check button click."""
         run_async(self._check_writing())
     
-    def save_state(self):
+    def save_state(self, *_, path: str | None = None, auto: bool = False):
         """Save the current application state."""
+        if path is None and not auto:
+            path, _ = QFileDialog.getSaveFileName(
+                self,
+                "Save State",
+                get_state_path().replace(".json", ".lts"),
+                "Language Tutor State (*.lts);;JSON (*.json)"
+            )
+        if path is None or path == "":
+            path = get_state_path()
         try:
-            self.state.save()
-            self.statusBar().showMessage("State saved successfully.", 3000)
+            self.state.save(path)
+            if not auto:
+                self.statusBar().showMessage("State saved successfully.", 3000)
         except Exception as e:
             QMessageBox.critical(self, "Error Saving State", str(e))
     
-    def load_state(self):
+    def load_state(self, *_, path: str | None = None, auto: bool = False):
         """Load the application state."""
-        if not os.path.exists(get_state_path()):
-            self.statusBar().showMessage("No saved state found.", 3000)
+        if path is None and not auto:
+            path, _ = QFileDialog.getOpenFileName(
+                self,
+                "Load State",
+                get_state_path().replace(".json", ".lts"),
+                "Language Tutor State (*.lts *.json)"
+            )
+        if path is None or path == "":
+            path = get_state_path()
+        if not os.path.exists(path):
+            if not auto:
+                self.statusBar().showMessage("No saved state found.", 3000)
             return
 
         try:
-            state = LanguageTutorState.load()
+            state = LanguageTutorState.load(path)
             self.state = state
             
             # Restore language first (this will reload definitions)
@@ -693,3 +715,10 @@ class LanguageTutorGUI(QMainWindow):
             # Reload API key
             llm.set_api_key(os.getenv("OPENROUTER_API_KEY", ""))
             self.statusBar().showMessage("Settings updated successfully.", 3000)
+
+    def closeEvent(self, event):
+        """Automatically save state when the window is closed."""
+        try:
+            self.save_state(auto=True)
+        finally:
+            super().closeEvent(event)

--- a/src/language_tutor/state.py
+++ b/src/language_tutor/state.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, asdict, field
 import json
 import os
 from typing import Optional
+import toml
 
 from .config import get_state_path
 
@@ -27,21 +28,39 @@ class LanguageTutorState:
         return asdict(self)
 
     def save(self, path: Optional[str] = None) -> None:
-        """Serialize the state to JSON."""
+        """Serialize the state to file.
+
+        If the file extension is ``.json`` the state is stored as JSON,
+        otherwise it is stored in ``toml`` format.  When ``path`` is
+        omitted the default location returned by :func:`get_state_path`
+        is used.
+        """
         if path is None:
             path = get_state_path()
+        ext = os.path.splitext(path)[1].lower()
         with open(path, "w") as f:
-            json.dump(self.to_dict(), f)
+            if ext == ".json":
+                json.dump(self.to_dict(), f)
+            else:
+                toml.dump(self.to_dict(), f)
 
     @classmethod
     def load(cls, path: Optional[str] = None) -> "LanguageTutorState":
-        """Load state from JSON file."""
+        """Load state from file.
+
+        If the file extension is ``.json`` the state is interpreted as
+        JSON, otherwise it is treated as ``toml``.
+        """
         if path is None:
             path = get_state_path()
         if not os.path.exists(path):
             return cls()
+        ext = os.path.splitext(path)[1].lower()
         with open(path, "r") as f:
-            data = json.load(f)
+            if ext == ".json":
+                data = json.load(f)
+            else:
+                data = toml.load(f)
         return cls(**data)
 
 


### PR DESCRIPTION
## Summary
- implement state save/load using TOML or JSON depending on extension
- add file dialogs for choosing state files in TUI and GUI apps
- automatically load previous session on start and save on exit

## Testing
- `pytest -q` *(fails: `pytest` not found)*