### PR TITLE
Fix wiktionary locale handling

### DIFF
--- a/src/language_tutor/gui_app.py
+++ b/src/language_tutor/gui_app.py
@@ -864,7 +864,7 @@ class LanguageTutorGUI(QMainWindow):
 
     def open_wiktionary_dialog(self):
         """Open the Wiktionary lookup dialog."""
-        dialog = WiktionaryDialog(self)
+        dialog = WiktionaryDialog(self, language=self.selected_language or "en")
         dialog.exec_()
 
     def open_settings_dialog(self):

--- a/src/language_tutor/gui_screens/wiktionary_dialog.py
+++ b/src/language_tutor/gui_screens/wiktionary_dialog.py
@@ -1,6 +1,8 @@
 """Wiktionary lookup dialog."""
 
 import urllib.parse
+
+from language_tutor.utils import build_wiktionary_url
 from PyQt5.QtWidgets import (
     QDialog,
     QGridLayout,
@@ -19,8 +21,9 @@ from PyQt5.QtWebEngineWidgets import QWebEngineView
 class WiktionaryDialog(QDialog):
     """Dialog for searching words on Wiktionary."""
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, language: str = "en"):
         super().__init__(parent)
+        self.language = language
         self.setWindowTitle("Wiktionary Lookup")
         self.resize(1200, 900)
 
@@ -69,5 +72,5 @@ class WiktionaryDialog(QDialog):
         word = self.word_input.text().strip()
         if not word:
             return
-        url = "https://en.m.wiktionary.org/wiki/" + urllib.parse.quote(word)
+        url = build_wiktionary_url(word, self.language)
         self.web_view.load(QUrl(url))

--- a/src/language_tutor/utils.py
+++ b/src/language_tutor/utils.py
@@ -1,0 +1,23 @@
+"""Utility functions for the Language Tutor application."""
+
+from __future__ import annotations
+
+import urllib.parse
+
+
+def build_wiktionary_url(word: str, language: str = "en") -> str:
+    """Return the mobile Wiktionary URL for ``word`` in the given ``language``.
+
+    Parameters
+    ----------
+    word:
+        Word to look up.
+    language:
+        Two-letter language code such as ``"en"`` or ``"pl"``.  Only the
+        first part before ``'-'`` is used.
+    """
+    if not word:
+        return ""
+    lang = (language or "en").split("-")[0]
+    quoted = urllib.parse.quote(word)
+    return f"https://{lang}.m.wiktionary.org/wiki/{quoted}"

--- a/tests/test_wiktionary_url.py
+++ b/tests/test_wiktionary_url.py
@@ -1,0 +1,6 @@
+from language_tutor.utils import build_wiktionary_url
+
+
+def test_build_wiktionary_url():
+    assert build_wiktionary_url("test", "pl") == "https://pl.m.wiktionary.org/wiki/test"
+    assert build_wiktionary_url("café", "en") == "https://en.m.wiktionary.org/wiki/caf%C3%A9"


### PR DESCRIPTION
## Summary
- pass the selected language to WiktionaryDialog
- generate Wiktionary URL with new `build_wiktionary_url` helper
- add tests for URL generation

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*