### PR TITLE
Add file sync capability

### DIFF
--- a/src/language_tutor/config.py
+++ b/src/language_tutor/config.py
@@ -1,6 +1,7 @@
 """Configuration and constants for the Language Tutor app."""
 
 import os
+import json
 
 try:
     from litellm.types.utils import CostPerToken
@@ -91,3 +92,23 @@ def get_export_path():
     if not os.path.exists(path):
         os.makedirs(path)
     return path
+
+
+def load_config() -> dict:
+    """Load JSON configuration."""
+    path = get_config_path()
+    if os.path.exists(path):
+        try:
+            with open(path, "r") as f:
+                return json.load(f)
+        except Exception:
+            return {}
+    return {}
+
+
+def save_config(data: dict) -> None:
+    """Merge and save configuration to disk."""
+    cfg = load_config()
+    cfg.update(data)
+    with open(get_config_path(), "w") as f:
+        json.dump(cfg, f)

--- a/src/language_tutor/state.py
+++ b/src/language_tutor/state.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 from dataclasses import asdict, dataclass, field
 from typing import Optional
 
@@ -9,6 +10,14 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for older versions
     import toml
 
 from .config import get_state_path
+
+
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _strip_html(text: str) -> str:
+    """Remove simple HTML tags from ``text``."""
+    return _TAG_RE.sub("", text)
 
 
 @dataclass
@@ -69,12 +78,12 @@ class LanguageTutorState:
 
     def to_markdown(self) -> str:
         """Return a Markdown representation of the current state."""
-        exercise = self.generated_exercise or ""
-        hints = self.generated_hints or ""
-        writing = self.writing_input or ""
-        mistakes = self.writing_mistakes or ""
-        style = self.style_errors or ""
-        recs = self.recommendations or ""
+        exercise = _strip_html(self.generated_exercise or "")
+        hints = _strip_html(self.generated_hints or "")
+        writing = _strip_html(self.writing_input or "")
+        mistakes = _strip_html(self.writing_mistakes or "")
+        style = _strip_html(self.style_errors or "")
+        recs = _strip_html(self.recommendations or "")
         return f"""# Language Tutor Export
 
 **Language:** {self.selected_language}

--- a/tests/test_file_sync.py
+++ b/tests/test_file_sync.py
@@ -1,0 +1,36 @@
+import os
+import pytest
+
+PyQt5 = pytest.importorskip("PyQt5")
+from PyQt5.QtWidgets import QApplication
+from language_tutor.gui_app import LanguageTutorGUI
+from language_tutor.languages import exercise_types, definitions
+
+
+def _make_gui(tmp_path):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance() or QApplication([])
+    gui = LanguageTutorGUI(exercise_types=exercise_types, exercise_definitions=definitions)
+    gui.file_sync_enabled = True
+    gui.file_sync_path = str(tmp_path / "sync.txt")
+    gui._configure_file_sync()
+    return gui
+
+
+def test_reload_from_file(tmp_path):
+    gui = _make_gui(tmp_path)
+    path = gui.file_sync_path
+    with open(path, "w") as f:
+        f.write("hello")
+    gui._on_sync_file_changed(path)
+    assert gui.writing_input_area.toPlainText() == "hello"
+
+
+def test_delayed_save(tmp_path):
+    gui = _make_gui(tmp_path)
+    gui.writing_input_area.setText("new")
+    gui._on_writing_changed()
+    assert gui._save_timer.isActive()
+    gui._save_sync_file()
+    with open(gui.file_sync_path) as f:
+        assert f.read() == "new"


### PR DESCRIPTION
## Summary
- extend config module with JSON helpers
- allow configuring file sync path in SettingsDialog
- add file sync support in LanguageTutorGUI via QFileSystemWatcher and QTimer
- strip HTML tags when exporting state
- test file sync behaviour

## Testing
- `PYTHONPATH=src pytest -q`